### PR TITLE
Add generic message for timeout error

### DIFF
--- a/app/scripts/connect/registration.controller.coffee
+++ b/app/scripts/connect/registration.controller.coffee
@@ -80,7 +80,10 @@ RegistrationController = ($state, $stateParams, $scope, ISO3166) ->
     $scope.$apply ->
       vm.error        = true
       vm.loading      = false
-      vm.errorMessage = error.message
+      if error.message.indexOf('JSON') != -1
+        vm.errorMessage = 'Server error, please try again'
+      else
+        vm.errorMessage = error.message
 
   registerSuccess = (user) ->
     # options =


### PR DESCRIPTION
Replace "Unexpected end of JSON input" with 'Server error, please try again'
Response code 504 indicates that the server timed out so JSON.parse fails
https://github.com/appirio-tech/connect-app/issues/980
https://github.com/appirio-tech/connect-app/issues/1070