### PR TITLE
Set an overflow height for autocomplete dropdown

### DIFF
--- a/app/styles/connect/connect.scss
+++ b/app/styles/connect/connect.scss
@@ -5,6 +5,11 @@
   min-height: 100vh;
   font-family: 'Roboto', sans-serif;
 
+  .angucomplete-dropdown {
+    overflow-y: auto;
+    max-height: 10 * 6 * $base-unit;
+  }
+  
   h2 {
     margin: 0 (4 * $base-unit) (2 * $base-unit);
     font-weight: 300;


### PR DESCRIPTION
10 entries seems like a reasonable choice (10 * line height of a paragraph)
https://github.com/appirio-tech/connect-app/issues/1070
https://github.com/appirio-tech/connect-app/issues/1015